### PR TITLE
Use travis.ci to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: clojure


### PR DESCRIPTION
Let's use [travis](https://docs.travis-ci.com/user/getting-started/) to build our open source projects.