### PR TITLE
Implement metrics collection in Conduit

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,11 @@
-(defproject com.farmlogs.conduit "0.1.0"
+(defproject com.farmlogs.conduit "0.1.1-SNAPSHOT"
   :description "Provides reliable publishing via RMQ."
   :license {:name "The MIT License (MIT)"
             :url "https://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [com.novemberain/langohr "3.4.1"]
-                 [com.stuartsierra/component "0.3.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [com.novemberain/langohr "3.5.1"]
+                 [metrics-clojure "2.6.1"]
+                 [com.stuartsierra/component "0.3.1"]
                  [org.clojure/core.async "0.2.374"]
                  [org.clojure/tools.logging "0.3.1"]]
 


### PR DESCRIPTION
# Goals

Per queue, measure:
1. Time taken to process messages
1a. work time
1b. time waiting to be ack'd
2. Count # of `:ack`,`:retry`,`:drop`'d messages
3. How many messages are stored on the consumer waiting to be worked on
4. Measure how long it takes to publish messages
5. Count # of publishes resulting in `:success`,`:failure`,`:timeout`,`:closed` 

# Implementation Strategy

Implementing a new core.async buffer type to do our metrics seems the simplest (RH sense). There are [4 events that can happen on buffers](https://github.com/clojure/core.async/blob/master/src/main/clojure/clojure/core/async/impl/protocols.clj#L31-L35). Buffer creation is an event. A buffer can have an item added to it. It can have an item removed, and it can be closed. If we had a buffer that allows its creator to hook into these events, we could instrument the entire dataflow in conduit.

We will implement a new buffer type, possibly called a `HookedBuffer` (plz help w/name). We will then use these hooks to emit the appropriate metrics.

## Pros/Cons

| Pro | Con |
|------|-------|
| Minimal impact on conduit as it currently works      |  Code running in a "hook" is inside the `async/>!` and `async/<!` locks. If it's slow it could be very detrimental to throughput.       |
| `HookedBuffer` is easily reusable. could even be easily lifted into its own lib | |
| It's trivial to turn on/off the use of `HookedBuffer` via feature flags | |

## Subscription

### Implementation Review

The data-flow of a subscription looks like the following:

![conduitsubscription](https://cloud.githubusercontent.com/assets/134571/15503563/86b2aba2-2188-11e6-89ab-8a7613c450b4.png)

When a new message arrives from RMQ, the `Subscrtiption` creates a core.async channel called `result-chan`. The purpose of the `result-chan` is to convey the results of handling the message from the workers to the process responsible for acknowledging the work. For example, after a worker successfully finishes processing the RMQ message, it enqueues an `:ack` on the `result-chan` and the acknowledgement process the reads it and can alert the RMQ broker that the message was successfully handled.

In order to make the `result-chan` available to both a worker and the acknowledgement process, the `result-chan` is placed on both the `pending-messages` ([here](https://github.com/FarmLogs/conduit/blob/metrics/src/com/farmlogs/conduit/subscription.clj#L25)) and `new-messages` ([here](https://github.com/FarmLogs/conduit/blob/metrics/src/com/farmlogs/conduit/subscription.clj#L20)) (names could be better) core.async channels. It is placed on the `pending-messages` channel with the RMQ message payload and on the `new-messages` channel with the RMQ message headers. These enable the recipients to do the work they are intended to do. The recipients of events on `pending-messages` are worker processes, and the recipients of events on the `new-messages` channel is the acknowledgement process.

### Changes to enable metrics

Instrument the channels as follows:

#### Result Chan

| buffer create | buffer add! | buffer remove | buffer close |
|-------------------|---------------|--------------------|------------------|
| start a timer to measure work time | stop work time timer, start ack time timer | ack time done, count ack type | noting |

#### Pending Chan

| buffer create | buffer add! | buffer remove | buffer close |
|-------------------|---------------|--------------------|------------------|
| nothing          | incr the "awaiting worker" counter | decr the "awaiting worker" counter | nothing |

#### New Messages Chan

| buffer create | buffer add! | buffer remove | buffer close |
|-------------------|---------------|--------------------|------------------|
| nothing         | incr the "awaiting ack" counter | decr the "awaiting ack" counter | nothing |

## Reliable Publish

Reliable publish is easier to instrument. There's less going on. The reliable publish code returns a channel to the publisher ([code](https://github.com/FarmLogs/conduit/blob/master/src/com/farmlogs/conduit/reliable_channel.clj#L189)). This is the only channel with events that are worth measuring.

#### New Messages Chan

| buffer create | buffer add! | buffer remove | buffer close |
|-------------------|---------------|--------------------|------------------|
| start the publication timer | incr the appropriate result type counter (eg. `:success` or `:timeout` counter), stop the publication timer | nothing | nothing.