### PR TITLE
Reliable publish usability

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.farmlogs.conduit "0.2.1-SNAPSHOT"
+(defproject com.farmlogs.conduit "0.2.0-SNAPSHOT"
   :description "Provides reliable publishing via RMQ."
   :license {:name "The MIT License (MIT)"
             :url "https://opensource.org/licenses/MIT"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.farmlogs.conduit "0.2.0"
+(defproject com.farmlogs.conduit "0.2.1-SNAPSHOT"
   :description "Provides reliable publishing via RMQ."
   :license {:name "The MIT License (MIT)"
             :url "https://opensource.org/licenses/MIT"}

--- a/src/com/farmlogs/conduit/connection.clj
+++ b/src/com/farmlogs/conduit/connection.clj
@@ -1,5 +1,6 @@
 (ns com.farmlogs.conduit.connection
   (:require [com.stuartsierra.component :as component]
+            [com.farmlogs.conduit.protocols :as p]
             [clojure.tools.logging :as log]
             [langohr.core :as rmq]))
 
@@ -14,7 +15,10 @@
   (stop [this]
     (log/info "Stopping RMQ")
     (rmq/close conn)
-    (log/info "Stopped RMQ")))
+    (log/info "Stopped RMQ"))
+
+  p/RMQConnection
+  (connection [_] conn))
 
 (defn connection
   [uri]

--- a/src/com/farmlogs/conduit/protocols.clj
+++ b/src/com/farmlogs/conduit/protocols.clj
@@ -6,15 +6,25 @@
     described by the message-metadata."))
 
 (defprotocol ReliablePublish
-  "Publish a message. Return a core.async chan that indicates if the
-  publication was successful.
-
-  Headers must contain the following keys:
-
-   - exchange :: The name of the exchange to publish to.
-   - routing-key :: The topic or queue name that this message should
-                    be routed to.
-
-  The chan will yield one of #{:success :failure :timeout :closed :error}"
   (publish!
-   [transport message headers]))
+    [transport message headers]
+    "Publish a message. Return a core.async chan that indicates if the
+     publication was successful.
+
+     Headers must contain the following keys:
+
+      - exchange :: The name of the exchange to publish to.
+      - routing-key :: The topic or queue name that this message should
+                       be routed to.
+
+     The chan will yield one of #{:success :failure :timeout :closed :error}")
+  (publish!! [transport message headers]
+    "Publish a message. Return one of:
+          #{:success :failure :timeout :closed :error}
+     indicating if the publication was successful.
+
+     Headers must contain the following keys:
+
+      - exchange :: The name of the exchange to publish to.
+      - routing-key :: The topic or queue name that this message should
+                       be routed to."))

--- a/src/com/farmlogs/conduit/protocols.clj
+++ b/src/com/farmlogs/conduit/protocols.clj
@@ -28,3 +28,7 @@
       - exchange :: The name of the exchange to publish to.
       - routing-key :: The topic or queue name that this message should
                        be routed to."))
+
+(defprotocol RMQConnection
+  "Return an com.rabbitmq.client.Connection."
+  (connection [this]))

--- a/src/com/farmlogs/conduit/reliable_channel.clj
+++ b/src/com/farmlogs/conduit/reliable_channel.clj
@@ -187,7 +187,7 @@
 
   component/Lifecycle
   (start [{:keys [rmq-connection timeout-window] :as this}]
-    (let [rmq-chan (rmq.chan/open rmq-connection)
+    (let [rmq-chan (rmq.chan/open (:conn rmq-connection))
           confirmation-chan (a/chan)
           await-chan (a/chan)
           await-process (->await-process confirmation-chan await-chan timeout-window)]

--- a/src/com/farmlogs/conduit/reliable_channel.clj
+++ b/src/com/farmlogs/conduit/reliable_channel.clj
@@ -173,6 +173,10 @@
                      :routing-key routing-key
                      :body  (.encodeToString (Base64/getEncoder) body)}))))))
 
+(extend-type com.rabbitmq.client.Connection
+  p/RMQConnection
+  (connection [this] this))
+
 (defrecord ReliableChan
     [await-chan await-process rmq-chan]
   java.lang.AutoCloseable
@@ -187,7 +191,7 @@
 
   component/Lifecycle
   (start [{:keys [rmq-connection timeout-window] :as this}]
-    (let [rmq-chan (rmq.chan/open (:conn rmq-connection))
+    (let [rmq-chan (rmq.chan/open (p/connection rmq-connection))
           confirmation-chan (a/chan)
           await-chan (a/chan)
           await-process (->await-process confirmation-chan await-chan timeout-window)]


### PR DESCRIPTION
Two changes:

* Add `publish!!` to the `ReliablePublish` protocol
* make `ReliableChannel`

The publish!! function can be used to reliably publish to RMQ in a synchronous manner. It also enables client code to not depend on core.async.

Make the `->reliable-chan` return a `ReliableChannel`. This enables client code to extend it to new protocols.

`ReliableChannel` participates in component/Lifecycle.

NOTE: `ReliableChannel` is not intended to be used globally!